### PR TITLE
✨ feat(auth): implementa refresh token e testes de autorizacao

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       DATABASE_URL: 'sqlite+aiosqlite:///./test.db'
       SECRET_KEY: 'super-secret-key-for-testing-purposes-only'
       ALGORITHM: 'HS256'
-      ACCESS_TOKEN_EXPIRE_DAYS: '7'
+      ACCESS_TOKEN_EXPIRE_DAYS: '1'
 
     steps:
       # ... (o resto do arquivo continua igual) ...

--- a/fastapi_zero/database.py
+++ b/fastapi_zero/database.py
@@ -5,6 +5,6 @@ from fastapi_zero.settings import Settings
 engine = create_async_engine(Settings().DATABASE_URL)
 
 
-async def get_session():
+async def get_session():  # pragma: no cover
     async with AsyncSession(engine, expire_on_commit=False) as session:
         yield session

--- a/fastapi_zero/routers/auth.py
+++ b/fastapi_zero/routers/auth.py
@@ -11,6 +11,7 @@ from fastapi_zero.models import User
 from fastapi_zero.schemas import Token
 from fastapi_zero.security import (
     create_access_token,
+    get_current_user,
     verify_password,
 )
 
@@ -19,6 +20,7 @@ router = APIRouter(prefix='/auth', tags=['auth'])
 
 AsyncSession = Annotated[AsyncSession, Depends(get_session)]
 OAuth2Form = Annotated[OAuth2PasswordRequestForm, Depends()]
+CurrentUser = Annotated[User, Depends(get_current_user)]
 
 
 @router.post('/token', response_model=Token)
@@ -45,3 +47,12 @@ async def login_for_access_token(
     access_token = create_access_token(data={'sub': user.email})
 
     return {'access_token': access_token, 'token_type': 'Bearer'}
+
+
+@router.post('/refresh_token', response_model=Token)
+async def refresh_access_token(
+    user: CurrentUser,
+):
+    new_access_token = create_access_token(data={'sub': user.email})
+
+    return {'access_token': new_access_token, 'token_type': 'Bearer'}

--- a/fastapi_zero/security.py
+++ b/fastapi_zero/security.py
@@ -4,7 +4,7 @@ from zoneinfo import ZoneInfo
 
 from fastapi import Depends, HTTPException
 from fastapi.security import OAuth2PasswordBearer
-from jwt import DecodeError, decode, encode
+from jwt import DecodeError, ExpiredSignatureError, decode, encode
 from pwdlib import PasswordHash
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -61,6 +61,11 @@ async def get_current_user(
             raise credentials_exception
     except DecodeError:
         raise credentials_exception
+    except ExpiredSignatureError:
+        raise HTTPException(
+            status_code=HTTPStatus.UNAUTHORIZED,
+            detail='Could not validate credentials',
+        )
 
     user = await session.scalar(
         select(User).where(User.email == subject_email)

--- a/poetry.lock
+++ b/poetry.lock
@@ -393,6 +393,40 @@ dnspython = ">=2.0.0"
 idna = ">=2.0.0"
 
 [[package]]
+name = "factory-boy"
+version = "3.3.3"
+description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "factory_boy-3.3.3-py2.py3-none-any.whl", hash = "sha256:1c39e3289f7e667c4285433f305f8d506efc2fe9c73aaea4151ebd5cdea394fc"},
+    {file = "factory_boy-3.3.3.tar.gz", hash = "sha256:866862d226128dfac7f2b4160287e899daf54f2612778327dd03d0e2cb1e3d03"},
+]
+
+[package.dependencies]
+Faker = ">=0.7.0"
+
+[package.extras]
+dev = ["Django", "Pillow", "SQLAlchemy", "coverage", "flake8", "isort", "mongoengine", "mongomock", "mypy", "tox", "wheel (>=0.32.0)", "zest.releaser[recommended]"]
+doc = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
+
+[[package]]
+name = "faker"
+version = "37.4.0"
+description = "Faker is a Python package that generates fake data for you."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "faker-37.4.0-py3-none-any.whl", hash = "sha256:cb81c09ebe06c32a10971d1bbdb264bb0e22b59af59548f011ac4809556ce533"},
+    {file = "faker-37.4.0.tar.gz", hash = "sha256:7f69d579588c23d5ce671f3fa872654ede0e67047820255f43a4aa1925b89780"},
+]
+
+[package.dependencies]
+tzdata = "*"
+
+[[package]]
 name = "fastapi"
 version = "0.115.12"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -455,6 +489,21 @@ files = [
 docs = ["furo (>=2024.8.6)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
 testing = ["covdefaults (>=2.3)", "coverage (>=7.6.10)", "diff-cover (>=9.2.1)", "pytest (>=8.3.4)", "pytest-asyncio (>=0.25.2)", "pytest-cov (>=6)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.28.1)"]
 typing = ["typing-extensions (>=4.12.2) ; python_version < \"3.11\""]
+
+[[package]]
+name = "freezegun"
+version = "1.5.2"
+description = "Let your Python tests travel through time"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "freezegun-1.5.2-py3-none-any.whl", hash = "sha256:5aaf3ba229cda57afab5bd311f0108d86b6fb119ae89d2cd9c43ec8c1733c85b"},
+    {file = "freezegun-1.5.2.tar.gz", hash = "sha256:a54ae1d2f9c02dbf42e02c18a3ab95ab4295818b549a34dac55592d72a905181"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.7"
 
 [[package]]
 name = "greenlet"
@@ -1231,6 +1280,21 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["dev"]
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -1394,6 +1458,18 @@ groups = ["main"]
 files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["dev"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
 
 [[package]]
@@ -1626,6 +1702,18 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.12.0"
+
+[[package]]
+name = "tzdata"
+version = "2025.2"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+groups = ["dev"]
+files = [
+    {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
+    {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
+]
 
 [[package]]
 name = "uvicorn"
@@ -1893,4 +1981,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "bda6f9d6c0c468bff6d60fd8779c50ef5f74c98da4666f2a95ac26d2e73f2adc"
+content-hash = "d69c176334d86df3cca5069f190118cc497ceaa23a33719bd73504812feb75bf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ taskipy = '^1.14.1'
 ruff = '^0.11.13'
 pre-commit = "3.7.1"
 pytest-asyncio = "^1.0.0"
+factory-boy = "^3.3.3"
+freezegun = "^1.5.2"
 
 [tool.ruff]
 line-length = 79

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from datetime import datetime
 
+import factory
 import pytest
 import pytest_asyncio
 from fastapi.testclient import TestClient
@@ -69,9 +70,24 @@ def mock_db_time():
 async def user(session: AsyncSession):
     password = 'testtest'
 
-    user = User(
-        username='teste',
-        email='teste@test.com',
+    user = UserFactory(
+        password=get_password_hash(password),
+    )
+
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+
+    user.clean_password = password
+
+    return user
+
+
+@pytest_asyncio.fixture
+async def other_user(session: AsyncSession):
+    password = 'testtest'
+
+    user = UserFactory(
         password=get_password_hash(password),
     )
 
@@ -100,3 +116,12 @@ def token(client, user):
 @pytest.fixture
 def settings():
     return Settings()
+
+
+class UserFactory(factory.Factory):
+    class Meta:
+        model = User
+
+    username = factory.Sequence(lambda n: f'username{n}')
+    email = factory.LazyAttribute(lambda obj: f'{obj.username}@example.com')
+    password = factory.LazyAttribute(lambda obj: 'secret')

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,7 @@
 from http import HTTPStatus
 
+from freezegun import freeze_time
+
 
 def test_get_token(client, user):
     response = client.post(
@@ -15,3 +17,94 @@ def test_get_token(client, user):
     assert response.status_code == HTTPStatus.OK
     assert token['token_type'] == 'Bearer'
     assert 'access_token' in token
+
+
+def test_token_expired_after_time(client, user):
+    with freeze_time('2025-05-20 12:00:00'):
+        response = client.post(
+            'auth/token',
+            data={
+                'username': user.email,
+                'password': user.clean_password,
+            },
+        )
+
+    assert response.status_code == HTTPStatus.OK
+    token = response.json()['access_token']
+
+    with freeze_time('2025-05-21 12:01:00'):
+        response = client.put(
+            f'/users/{user.id}/',
+            headers={'Authorization': f'Bearer {token}'},
+            json={
+                'username': 'wrong',
+                'email': 'wrong@example.com',
+                'password': 'secret',
+            },
+        )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert response.json() == ({'detail': 'Could not validate credentials'})
+
+
+def test_token_wrong_password(client, user):
+    response = client.post(
+        'auth/token',
+        data={
+            'username': user.email,
+            'password': 'wrong',
+        },
+    )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert response.json() == ({'detail': 'Incorrect email or password'})
+
+
+def test_token_wrong_email(client, user):
+    response = client.post(
+        'auth/token',
+        data={
+            'username': 'wrong',
+            'password': user.clean_password,
+        },
+    )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert response.json() == ({'detail': 'Incorrect email or password'})
+
+
+def test_refresh_token(client, token):
+    response = client.post(
+        'auth/refresh_token',
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    data = response.json()
+
+    assert response.status_code == HTTPStatus.OK
+    assert data['token_type'] == 'Bearer'
+    assert 'token_type' in data
+    assert 'access_token' in data
+
+
+def test_token_expired_dont_refresh(client, user):
+    with freeze_time('2025-05-20 12:00:00'):
+        response = client.post(
+            'auth/token',
+            data={
+                'username': user.email,
+                'password': user.clean_password,
+            },
+        )
+
+    assert response.status_code == HTTPStatus.OK
+    token = response.json()['access_token']
+
+    with freeze_time('2025-05-21 12:01:00'):
+        response = client.post(
+            'auth/refresh_token',
+            headers={'Authorization': f'Bearer {token}'},
+        )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert response.json() == ({'detail': 'Could not validate credentials'})

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -25,3 +25,27 @@ def test_jwt_invalid_token(client):
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED
     assert response.json() == {'detail': 'Could not validate credentials'}
+
+
+def test_get_current_user_missing_sub_in_token(client, settings, user):
+    token_data_without_sub = {'some_other_claim': 'some_value'}
+    access_token = create_access_token(token_data_without_sub)
+
+    response = client.delete(
+        f'/users/{user.id}/',
+        headers={'Authorization': f'Bearer {access_token}'},
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert response.json() == {'detail': 'Could not validate credentials'}
+
+
+def test_get_current_user_non_existent_user(client, settings, user):
+    token_data = {'sub': 'nonexistentuser@example.com'}
+    access_token = create_access_token(token_data)
+
+    response = client.delete(
+        f'/users/{user.id}/',
+        headers={'Authorization': f'Bearer {access_token}'},
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert response.json() == {'detail': 'Could not validate credentials'}


### PR DESCRIPTION
Adiciona o fluxo de refresh token para melhorar a segurança e a experiência do usuário.

- Cria o endpoint `POST /auth/token_refresh` para emitir novos tokens de acesso.
- Ajusta os testes para cobrir cenários de autorização, verificando o acesso a rotas protegidas.